### PR TITLE
Fixed footer links to be in keeping with main site and fixed site width to be 100%

### DIFF
--- a/Membership/wwwroot/css/style.css
+++ b/Membership/wwwroot/css/style.css
@@ -175,7 +175,7 @@ p {
 }
 
 .page-section .media-list > * + * {
-    margin-top: 2rem;
+	margin-top: 2rem;
 }
 
 @font-face {
@@ -204,17 +204,17 @@ p > a {
     text-decoration: underline;
 }
 
-p > a:visited {
-    color: #68217a;
-}
+    p > a:visited {
+        color: #68217a;
+    }
 
-p > a:hover {
-    color: #e2068c;
-}
+    p > a:hover {
+        color: #e2068c;
+    }
 
-.page-section--purple p > a, .page-section--purple p > a:visited {
-    color: #fff;
-}
+    .page-section--purple p > a, .page-section--purple p > a:visited {
+        color: #fff;
+    }
 
 img {
     max-width: 100%;
@@ -234,9 +234,9 @@ img {
     margin-top: 0;
 }
 
-.site-button_row .site-button {
-    margin: 2rem 1rem 0 1rem;
-}
+    .site-button_row .site-button {
+        margin: 2rem 1rem 0 1rem;
+    }
 
 .site-button:hover {
     text-decoration: none;
@@ -252,10 +252,10 @@ img {
     color: #fff;
 }
 
-.site-button--pink:hover {
-    color: #e2068c;
-    background-color: #ebe0eb;
-}
+    .site-button--pink:hover {
+        color: #e2068c;
+        background-color: #ebe0eb;
+    }
 
 .animation-delay--8 {
     animation-delay: .8s;
@@ -301,14 +301,14 @@ img {
     line-height: 1em;
 }
 
-.main-menu_item a {
-    color: #999999;
-}
+    .main-menu_item a {
+        color: #999999;
+    }
 
-li.active a.nav-link,
-.main-menu_item a:hover {
-    color: #68217a;
-}
+         li.active a.nav-link,
+        .main-menu_item a:hover {
+            color: #68217a;
+        }
 
 @media screen and (min-width: 769px) {
     .main-menu_item + .main-menu_item {
@@ -332,59 +332,59 @@ li.active a.nav-link,
     transition: all ease .3s;
 }
 
-.site-social_icon a {
-    padding: 7px 10px;
-    display: block;
-    font-size: 1.8rem;
-    min-width: 40px;
-    text-align: center;
-}
+    .site-social_icon a {
+        padding: 7px 10px;
+        display: block;
+        font-size: 1.8rem;
+        min-width: 40px;
+        text-align: center;
+    }
 
-.site-social_icon .fas:before, .site-social_icon .fab:before {
-    color: #666666;
-    transition: all ease .3s;
-}
+    .site-social_icon .fas:before, .site-social_icon .fab:before {
+        color: #666666;
+        transition: all ease .3s;
+    }
 
-.site-social_icon svg {
-    fill: #666666;
-    transition: all ease .3s;
-}
+    .site-social_icon svg {
+        fill: #666666;
+        transition: all ease .3s;
+    }
 
 .site-social_icon--meetup:hover {
-    background-color: #e0393e;
+	background-color: #e0393e;
 }
 
-.site-social_icon--meetup:hover svg {
-    fill: #ffffff;
-}
+	.site-social_icon--meetup:hover svg {
+		fill: #ffffff;
+	}
 
-.site-social_icon--meetup:hover .fas:before, .site-social_icon--meetup:hover .fab:before {
-    color: #ffffff;
-}
+	.site-social_icon--meetup:hover .fas:before, .site-social_icon--meetup:hover .fab:before {
+		color: #ffffff;
+	}
 
 .site-social_icon--rss:hover {
     background-color: #ef922f;
 }
 
-.site-social_icon--rss:hover svg {
-    fill: #ffffff;
-}
+    .site-social_icon--rss:hover svg {
+        fill: #ffffff;
+    }
 
-.site-social_icon--rss:hover .fas:before, .site-social_icon--rss:hover .fab:before {
-    color: #ffffff;
-}
+    .site-social_icon--rss:hover .fas:before, .site-social_icon--rss:hover .fab:before {
+        color: #ffffff;
+    }
 
 .site-social_icon--twitter:hover {
     background-color: #00aced;
 }
 
-.site-social_icon--twitter:hover svg {
-    fill: #ffffff;
-}
+    .site-social_icon--twitter:hover svg {
+        fill: #ffffff;
+    }
 
-.site-social_icon--twitter:hover .fas:before, .site-social_icon--twitter:hover .fab:before {
-    color: #ffffff;
-}
+    .site-social_icon--twitter:hover .fas:before, .site-social_icon--twitter:hover .fab:before {
+        color: #ffffff;
+    }
 
 .icon-box {
     background-color: #f6f6f6;
@@ -392,15 +392,15 @@ li.active a.nav-link,
     padding: 2rem;
 }
 
-.icon-box > * + * {
-    margin-top: 2rem;
-}
+    .icon-box > * + * {
+        margin-top: 2rem;
+    }
 
-.icon-box .animated {
-    opacity: 0;
-    animation-name: none;
-    animation-duration: 1s;
-}
+    .icon-box .animated {
+        opacity: 0;
+        animation-name: none;
+        animation-duration: 1s;
+    }
 
 .icon-box_stat {
     font-size: 4.8rem;
@@ -419,9 +419,9 @@ li.active a.nav-link,
     height: 70px;
 }
 
-.icon-box_icon img {
-    height: 100%;
-}
+    .icon-box_icon img {
+        height: 100%;
+    }
 
 .latest_container {
     display: flex;
@@ -435,19 +435,19 @@ li.active a.nav-link,
     background-position-y: 15%;
 }
 
-.latest_container--news .latest_date span {
-    position: relative;
-    margin-bottom: -60px;
-    line-height: 1em;
-}
+    .latest_container--news .latest_date span {
+        position: relative;
+        margin-bottom: -60px;
+        line-height: 1em;
+    }
 
-.latest_container--news .latest_date.newstype-community {
-    background-image: url(/img/chat.png);
-}
+    .latest_container--news .latest_date.newstype-community {
+        background-image: url(/img/chat.png);
+    }
 
-.latest_container--news .latest_date.newstype-product {
-    background-image: url(/img/bullhorn.png);
-}
+    .latest_container--news .latest_date.newstype-product {
+        background-image: url(/img/bullhorn.png);
+    }
 
 .latest_date {
     font-size: 2.1rem;
@@ -459,9 +459,9 @@ li.active a.nav-link,
     padding: 8px 5px;
 }
 
-.latest_date img {
-    max-height: 80px;
-}
+    .latest_date img {
+        max-height: 80px;
+    }
 
 .latest_container:nth-child(even) .latest_date {
     background-color: #e1d2e4;
@@ -506,19 +506,19 @@ li.active a.nav-link,
     font-weight: bold;
 }
 
-.flash a:hover {
-    text-decoration: underline;
-    color: #fff;
-}
+    .flash a:hover {
+        text-decoration: underline;
+        color: #fff;
+    }
 
-.flash a:visited {
-    color: #fff;
-}
+    .flash a:visited {
+        color: #fff;
+    }
 
-.flash .close {
-    font-size: 3.2rem;
-    margin-top: 5px;
-}
+    .flash .close {
+        font-size: 3.2rem;
+        margin-top: 5px;
+    }
 
 #site-footer_container {
     position: relative;
@@ -533,26 +533,26 @@ li.active a.nav-link,
     margin-bottom: 0;
 }
 
-#site-footer_menu a {
-    color: #68217a;
-}
+    #site-footer_menu a {
+        color: #68217a;
+    }
 
-#site-footer_menu a:hover {
-    font-weight: bold;
-    text-decoration: none;
-}
+        #site-footer_menu a:hover {
+            font-weight: bold;
+            text-decoration: none;
+        }
 
-#site-footer_menu li {
-    list-style-type: none;
-}
+    #site-footer_menu li {
+        list-style-type: none;
+    }
 
-#site-footer_menu li + li {
-    margin-top: 3px;
-}
+        #site-footer_menu li + li {
+            margin-top: 3px;
+        }
 
-#site-footer_menu li:last-child {
-    margin-bottom: 0;
-}
+        #site-footer_menu li:last-child {
+            margin-bottom: 0;
+        }
 
 #site-footer_bookend {
     background-color: #68217a;

--- a/Membership/wwwroot/css/style.css
+++ b/Membership/wwwroot/css/style.css
@@ -165,13 +165,17 @@ p {
     font-size: 2rem;
 }
 
-.page-section p, ul li {
+.page-section p {
+    font-size: 16px;
+}
+
+.page-section ul li {
     font-size: 16px;
     margin-bottom: 0;
 }
 
 .page-section .media-list > * + * {
-	margin-top: 2rem;
+    margin-top: 2rem;
 }
 
 @font-face {
@@ -200,17 +204,17 @@ p > a {
     text-decoration: underline;
 }
 
-    p > a:visited {
-        color: #68217a;
-    }
+p > a:visited {
+    color: #68217a;
+}
 
-    p > a:hover {
-        color: #e2068c;
-    }
+p > a:hover {
+    color: #e2068c;
+}
 
-    .page-section--purple p > a, .page-section--purple p > a:visited {
-        color: #fff;
-    }
+.page-section--purple p > a, .page-section--purple p > a:visited {
+    color: #fff;
+}
 
 img {
     max-width: 100%;
@@ -230,9 +234,9 @@ img {
     margin-top: 0;
 }
 
-    .site-button_row .site-button {
-        margin: 2rem 1rem 0 1rem;
-    }
+.site-button_row .site-button {
+    margin: 2rem 1rem 0 1rem;
+}
 
 .site-button:hover {
     text-decoration: none;
@@ -248,10 +252,10 @@ img {
     color: #fff;
 }
 
-    .site-button--pink:hover {
-        color: #e2068c;
-        background-color: #ebe0eb;
-    }
+.site-button--pink:hover {
+    color: #e2068c;
+    background-color: #ebe0eb;
+}
 
 .animation-delay--8 {
     animation-delay: .8s;
@@ -297,14 +301,14 @@ img {
     line-height: 1em;
 }
 
-    .main-menu_item a {
-        color: #999999;
-    }
+.main-menu_item a {
+    color: #999999;
+}
 
-         li.active a.nav-link,
-        .main-menu_item a:hover {
-            color: #68217a;
-        }
+li.active a.nav-link,
+.main-menu_item a:hover {
+    color: #68217a;
+}
 
 @media screen and (min-width: 769px) {
     .main-menu_item + .main-menu_item {
@@ -328,59 +332,59 @@ img {
     transition: all ease .3s;
 }
 
-    .site-social_icon a {
-        padding: 7px 10px;
-        display: block;
-        font-size: 1.8rem;
-        min-width: 40px;
-        text-align: center;
-    }
-
-    .site-social_icon .fas:before, .site-social_icon .fab:before {
-        color: #666666;
-        transition: all ease .3s;
-    }
-
-    .site-social_icon svg {
-        fill: #666666;
-        transition: all ease .3s;
-    }
-
-.site-social_icon--meetup:hover {
-	background-color: #e0393e;
+.site-social_icon a {
+    padding: 7px 10px;
+    display: block;
+    font-size: 1.8rem;
+    min-width: 40px;
+    text-align: center;
 }
 
-	.site-social_icon--meetup:hover svg {
-		fill: #ffffff;
-	}
+.site-social_icon .fas:before, .site-social_icon .fab:before {
+    color: #666666;
+    transition: all ease .3s;
+}
 
-	.site-social_icon--meetup:hover .fas:before, .site-social_icon--meetup:hover .fab:before {
-		color: #ffffff;
-	}
+.site-social_icon svg {
+    fill: #666666;
+    transition: all ease .3s;
+}
+
+.site-social_icon--meetup:hover {
+    background-color: #e0393e;
+}
+
+.site-social_icon--meetup:hover svg {
+    fill: #ffffff;
+}
+
+.site-social_icon--meetup:hover .fas:before, .site-social_icon--meetup:hover .fab:before {
+    color: #ffffff;
+}
 
 .site-social_icon--rss:hover {
     background-color: #ef922f;
 }
 
-    .site-social_icon--rss:hover svg {
-        fill: #ffffff;
-    }
+.site-social_icon--rss:hover svg {
+    fill: #ffffff;
+}
 
-    .site-social_icon--rss:hover .fas:before, .site-social_icon--rss:hover .fab:before {
-        color: #ffffff;
-    }
+.site-social_icon--rss:hover .fas:before, .site-social_icon--rss:hover .fab:before {
+    color: #ffffff;
+}
 
 .site-social_icon--twitter:hover {
     background-color: #00aced;
 }
 
-    .site-social_icon--twitter:hover svg {
-        fill: #ffffff;
-    }
+.site-social_icon--twitter:hover svg {
+    fill: #ffffff;
+}
 
-    .site-social_icon--twitter:hover .fas:before, .site-social_icon--twitter:hover .fab:before {
-        color: #ffffff;
-    }
+.site-social_icon--twitter:hover .fas:before, .site-social_icon--twitter:hover .fab:before {
+    color: #ffffff;
+}
 
 .icon-box {
     background-color: #f6f6f6;
@@ -388,15 +392,15 @@ img {
     padding: 2rem;
 }
 
-    .icon-box > * + * {
-        margin-top: 2rem;
-    }
+.icon-box > * + * {
+    margin-top: 2rem;
+}
 
-    .icon-box .animated {
-        opacity: 0;
-        animation-name: none;
-        animation-duration: 1s;
-    }
+.icon-box .animated {
+    opacity: 0;
+    animation-name: none;
+    animation-duration: 1s;
+}
 
 .icon-box_stat {
     font-size: 4.8rem;
@@ -415,9 +419,9 @@ img {
     height: 70px;
 }
 
-    .icon-box_icon img {
-        height: 100%;
-    }
+.icon-box_icon img {
+    height: 100%;
+}
 
 .latest_container {
     display: flex;
@@ -431,19 +435,19 @@ img {
     background-position-y: 15%;
 }
 
-    .latest_container--news .latest_date span {
-        position: relative;
-        margin-bottom: -60px;
-        line-height: 1em;
-    }
+.latest_container--news .latest_date span {
+    position: relative;
+    margin-bottom: -60px;
+    line-height: 1em;
+}
 
-    .latest_container--news .latest_date.newstype-community {
-        background-image: url(/img/chat.png);
-    }
+.latest_container--news .latest_date.newstype-community {
+    background-image: url(/img/chat.png);
+}
 
-    .latest_container--news .latest_date.newstype-product {
-        background-image: url(/img/bullhorn.png);
-    }
+.latest_container--news .latest_date.newstype-product {
+    background-image: url(/img/bullhorn.png);
+}
 
 .latest_date {
     font-size: 2.1rem;
@@ -455,9 +459,9 @@ img {
     padding: 8px 5px;
 }
 
-    .latest_date img {
-        max-height: 80px;
-    }
+.latest_date img {
+    max-height: 80px;
+}
 
 .latest_container:nth-child(even) .latest_date {
     background-color: #e1d2e4;
@@ -502,19 +506,19 @@ img {
     font-weight: bold;
 }
 
-    .flash a:hover {
-        text-decoration: underline;
-        color: #fff;
-    }
+.flash a:hover {
+    text-decoration: underline;
+    color: #fff;
+}
 
-    .flash a:visited {
-        color: #fff;
-    }
+.flash a:visited {
+    color: #fff;
+}
 
-    .flash .close {
-        font-size: 3.2rem;
-        margin-top: 5px;
-    }
+.flash .close {
+    font-size: 3.2rem;
+    margin-top: 5px;
+}
 
 #site-footer_container {
     position: relative;
@@ -529,26 +533,26 @@ img {
     margin-bottom: 0;
 }
 
-    #site-footer_menu a {
-        color: #68217a;
-    }
+#site-footer_menu a {
+    color: #68217a;
+}
 
-        #site-footer_menu a:hover {
-            font-weight: bold;
-            text-decoration: none;
-        }
+#site-footer_menu a:hover {
+    font-weight: bold;
+    text-decoration: none;
+}
 
-    #site-footer_menu li {
-        list-style-type: none;
-    }
+#site-footer_menu li {
+    list-style-type: none;
+}
 
-        #site-footer_menu li + li {
-            margin-top: 3px;
-        }
+#site-footer_menu li + li {
+    margin-top: 3px;
+}
 
-        #site-footer_menu li:last-child {
-            margin-bottom: 0;
-        }
+#site-footer_menu li:last-child {
+    margin-bottom: 0;
+}
 
 #site-footer_bookend {
     background-color: #68217a;
@@ -580,15 +584,15 @@ img {
     border-color: #e2068c;
 }
 
-body.pages .container-fluid {
+body .container-fluid {
     padding: 0;
 }
-body.pages .row {
+body .row {
     margin-right:0;
     margin-left:0;
 }
 
-body.pages main.col {
+body main.col {
     padding-right: 0;
     padding-left: 0;
 }


### PR DESCRIPTION
The members sub domain of the dotnetfoundation.org website differs slightly from the main website:

1. The footer links are bigger on the members sub domain
2. The site has padding on the members domain causing images not to use 100% of the screen

These are some small changes to the CSS to make them the same.

(If the differences are intentional then ignore this PR)

As I'm not (yet) a member of the dotnetfoundation I can't log in and check the rest of the members sub domain so that would be worth someone doing 😄 