### PR TITLE
Fixed Application Insights related warnings in dotnet build.

### DIFF
--- a/Membership/Startup.cs
+++ b/Membership/Startup.cs
@@ -174,6 +174,8 @@ namespace Membership
                 options.TokenValidationParameters.NameClaimType = "name";
                 options.TokenValidationParameters.RoleClaimType = "roles";
             });
+
+            services.AddApplicationInsightsTelemetry();
             
             services.AddMvc(options =>
             {
@@ -188,6 +190,8 @@ namespace Membership
 
 
             services.Configure<AdminConfig>(options => options.MembersGroupId = Configuration["AzureAd:MembersGroupId"]);
+
+            services.AddSingleton<ITelemetryInitializer, VersionTelemetry>();
 
             services.AddSingleton<IGraphApplicationClient>(sp =>
             {
@@ -243,10 +247,6 @@ namespace Membership
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }
-
-            loggerFactory.AddApplicationInsights(serviceProvider, Microsoft.Extensions.Logging.LogLevel.Information);
-
-            TelemetryConfiguration.Active.TelemetryInitializers.Add(new VersionTelemetry());
 
             app.UseHttpsRedirection();
             app.UseStaticFiles();


### PR DESCRIPTION
This PR is to fix the following two warnings.

> warning CS0618: 'TelemetryConfiguration.Active' is obsolete: 'We do not recommend using TelemetryConfiguration.Active on .NET Core. See https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152 for more details'

> warning CS0618: 'ApplicationInsightsLoggerFactoryExtensions.AddApplicationInsights(ILoggerFactory, IServiceProvider, LogLevel)' is obsolete: 'ApplicationInsightsLoggerProvider is now enabled by default when enabling ApplicationInsights monitoring using UseApplicationInsights extension method on IWebHostBuilder or AddApplicationInsightsTelemetry extension method on IServiceCollection. From 2.7.0-beta3 onwards, calling this method will result in double logging and filters applied will not get applied. If interested in using just logging provider, then please use Microsoft.Extensions.Logging.ApplicationInsightsLoggingBuilderExtensions.AddApplicationInsights from Microsoft.Extensions.Logging.ApplicationInsights package. Read more https://aka.ms/ApplicationInsightsILoggerFaq' 